### PR TITLE
Update _lastSequenceNumber to have unique source name

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -39,10 +39,10 @@ function Server(universes, port) {
   this.port = port || e131.DEFAULT_PORT;
   this._socket = dgram.createSocket({ type: 'udp4', reuseAddr: true });
   this._lastSequenceNumber = {};
-
+  
   var self = this;
   this.universes.forEach(function (universe) {
-    self._lastSequenceNumber[universe] = 0;
+    self._lastSequenceNumber[universe] = {};
   });
   this._socket.on('error', function onError(err) {
     self.emit('error', err);
@@ -60,12 +60,16 @@ function Server(universes, port) {
       self.emit('packet-error', packet, validation);
       return;
     }
-    if (packet.discard(self._lastSequenceNumber[packet.getUniverse()])) {
+    var lastSequenceNumber = self._lastSequenceNumber[packet.getUniverse()][packet.getSourceName()]
+    if(lastSequenceNumber === undefined) {
+      lastSequenceNumber = 0;
+    }
+    if (packet.discard(lastSequenceNumber)) {
       self.emit('packet-out-of-order', packet);
     } else {
       self.emit('packet', packet);
     }
-    self._lastSequenceNumber[packet.getUniverse()] = packet.getSequenceNumber();
+    self._lastSequenceNumber[packet.getUniverse()][packet.getSourceName()] = packet.getSequenceNumber();
   });
   this._socket.bind(this.port, function onListening() {
     self.universes.forEach(function (universe) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e131",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node.js client/server library for the E1.31 (sACN) protocol",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Ran into an issue where multiple sources writing to the same universe but had different sequence numbers and was causing packet-out-of-order events when it technically shouldn't